### PR TITLE
ignoring deckgl types on the client

### DIFF
--- a/client/.eslintrc.json
+++ b/client/.eslintrc.json
@@ -1,8 +1,8 @@
 {
   "extends": [
+    "next/core-web-vitals",
     "plugin:@typescript-eslint/recommended",
-    "plugin:prettier/recommended",
-    "next/core-web-vitals"
+    "plugin:prettier/recommended"
   ],
   "ignorePatterns": [
     "src/types/generated/*"

--- a/client/src/components/map/layers/deck-json-layer/index.tsx
+++ b/client/src/components/map/layers/deck-json-layer/index.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-var-requires */
 'use client';
 
 import { useEffect } from 'react';
@@ -9,6 +8,7 @@ import { useDeckMapboxOverlayContext } from '@/components/map/provider';
 
 export type DeckJsonLayerProps<T> = LayerProps &
   Partial<T> & {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     config: any;
   };
 

--- a/client/src/components/map/layers/deck-layer/index.tsx
+++ b/client/src/components/map/layers/deck-layer/index.tsx
@@ -8,6 +8,7 @@ import { useDeckMapboxOverlayContext } from '@/components/map/provider';
 
 export type DeckLayerProps<T> = LayerProps &
   T & {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     type: any;
   };
 

--- a/client/src/components/map/provider.tsx
+++ b/client/src/components/map/provider.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 'use client';
 
 import { createContext, PropsWithChildren, useCallback, useContext, useMemo, useRef } from 'react';


### PR DESCRIPTION
In order to avoid build issues I've decided to ignore temporary the types issues.
We shouldn't use `any` and this will be solved in another PR.